### PR TITLE
lz4:replace AOSP convention with cyanogenmod's

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,35 +1,5 @@
-LOCAL_PATH := $(call my-dir)
+# Copyright (C) 2015 The Android Open Source Project
 
-common_c_includes := $(LOCAL_PATH)/lib
-common_src_files :=  \
-    lib/lz4.c \
-    lib/lz4frame.c \
-    lib/lz4hc.c \
-    lib/xxhash.c \
-    programs/lz4io.c
+LOCAL_PATH:= $(call my-dir)
 
-include $(CLEAR_VARS)
-LOCAL_MODULE := liblz4-static
-LOCAL_C_INCLUDES := $(common_c_includes)
-LOCAL_SRC_FILES := $(common_src_files)
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := liblz4-host
-LOCAL_C_INCLUDES := $(common_c_includes)
-LOCAL_SRC_FILES := $(common_src_files)
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_HOST_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := lz4
-LOCAL_C_INCLUDES := $(common_c_includes)
-LOCAL_MODULE_TAGS := optional
-LOCAL_STATIC_LIBRARIES := liblz4-static
-
-LOCAL_SRC_FILES := \
-    programs/bench.c \
-    programs/lz4cli.c
-
-include $(BUILD_EXECUTABLE)
+include $(call all-makefiles-under,$(LOCAL_PATH))

--- a/lib/Android.mk
+++ b/lib/Android.mk
@@ -8,7 +8,7 @@ liblz4_common_cflags := -O3 -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-align
 LOCAL_ARM_MODE := arm
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := liblz4
+LOCAL_MODULE := liblz4-host
 LOCAL_SRC_FILES := $(liblz4_src_files)
 LOCAL_CFLAGS := $(liblz4_common_cflags)
 include $(BUILD_HOST_STATIC_LIBRARY)
@@ -20,7 +20,7 @@ LOCAL_CFLAGS := $(liblz4_common_cflags)
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := liblz4
+LOCAL_MODULE := liblz4-static
 LOCAL_SRC_FILES := $(liblz4_src_files)
 LOCAL_CFLAGS := $(liblz4_common_cflags)
 include $(BUILD_STATIC_LIBRARY)

--- a/programs/Android.mk
+++ b/programs/Android.mk
@@ -13,7 +13,7 @@ LOCAL_MODULE := lz4
 LOCAL_C_INCLUDES := $(lz4_common_c_includes)
 LOCAL_CFLAGS := $(lz4_common_cflags)
 LOCAL_SRC_FILES := $(lz4_common_src_files)
-LOCAL_STATIC_LIBRARIES := liblz4
+LOCAL_STATIC_LIBRARIES := liblz4-static
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_EXECUTABLE)
 
@@ -22,6 +22,6 @@ LOCAL_MODULE := lz4
 LOCAL_C_INCLUDES := $(lz4_common_c_includes)
 LOCAL_CFLAGS := $(lz4_common_cflags)
 LOCAL_SRC_FILES := $(lz4_common_src_files)
-LOCAL_STATIC_LIBRARIES := liblz4
+LOCAL_STATIC_LIBRARIES := liblz4-host
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_HOST_EXECUTABLE)


### PR DESCRIPTION
This patch brings up the Andoid.mk files's modules definitions with cyanogenmod instead of AOSP.
AOSP defines liblz4 for the libraries while cyanogenmod does liblz4-static for the target and liblz4-host for the host.

Therefore we need also to adjust potential future commits from AOSP using lz4 libs. This happened for example with android lollipop r3.
